### PR TITLE
fix: allow user to specify false for scrollock toggle

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ export const useScrollock = (
   let innerRef = useRef<HTMLElement>();
 
   const toggleScrollock = useCallback(
-    (value?: boolean) => setScrollock(value ? value : !scrollock),
+    (value?: boolean) => setScrollock(value ?? !scrollock),
     [scrollock]
   );
 


### PR DESCRIPTION
### Reason

Computing whether scroll should be enabled using `value ? value : !scrollock` will never let the user consistently programmatically disable scroll, since `false ? false : !scrollock` will always fall back on `!scrollock`. Using the nullish coalescing operator fixes this.

### Test Plan

Compiled using `npm run build`. Inspected the output of `dist/index.js` and it appears to build correctly with your configured ECMAScript version.